### PR TITLE
Support for TYPO3 9.5

### DIFF
--- a/Classes/Service/IpAuthenticationService.php
+++ b/Classes/Service/IpAuthenticationService.php
@@ -2,9 +2,9 @@
 
 namespace Snowflake\Sfpipauth\Service;
 
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Sv\AbstractAuthenticationService;
-
+use \TYPO3\CMS\Core\Authentication\AbstractAuthenticationService;
 
 /**
  * Class IpAuthenticationService
@@ -26,32 +26,12 @@ class IpAuthenticationService extends AbstractAuthenticationService
      */
     public function __construct()
     {
+        // Get all available ip configurations
+        $result = $this->getAllAvailableIpConfigurations();
 
-        try {
-            // Get all available ip configurations
-            $result = static::getDatabaseConnection()->exec_SELECTgetRows(
-                'ip,feusers,loginmode',
-                'tx_sfpipauth_ipconfiguration',
-                'hidden=0 AND deleted=0'
-            );
-
-            if (is_array($result)) {
-                $this->ipConfigurations = $result;
-            }
-        } catch (\InvalidArgumentException $e) {
-            // cannot happen anyways
+        if (is_array($result)) {
+            $this->ipConfigurations = $result;
         }
-    }
-
-
-    /**
-     * Gets the database object.
-     *
-     * @return \TYPO3\CMS\Core\Database\DatabaseConnection
-     */
-    protected static function getDatabaseConnection()
-    {
-        return $GLOBALS['TYPO3_DB'];
     }
 
 
@@ -74,6 +54,13 @@ class IpAuthenticationService extends AbstractAuthenticationService
         return $user;
     }
 
+    protected function getAllAvailableIpConfigurations() : array
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_sfpipauth_ipconfiguration');
+        return $queryBuilder->select('ip', 'feusers' ,'loginmode')->from('tx_sfpipauth_ipconfiguration')
+        ->execute()
+        ->fetchAll();
+    }
 
     /**
      * Find user which matches provided ip

--- a/Classes/Service/IpAuthenticationService.php
+++ b/Classes/Service/IpAuthenticationService.php
@@ -130,7 +130,7 @@ class IpAuthenticationService extends AbstractAuthenticationService
                 $ipMatch = GeneralUtility::cmpIP($userIp, $ipConfiguration['ip']);
                 $loginMode = (int)$ipConfiguration['loginmode'];
 
-                $authentications[] = array ($loginMode, $this->getAuthenticationByLoginMode($ipMatch, $loginMode));
+                $authentications[] = array($loginMode, $this->getAuthenticationByLoginMode($ipMatch, $loginMode));
 
             }
 

--- a/Configuration/TCA/tx_sfpipauth_ipconfiguration.php
+++ b/Configuration/TCA/tx_sfpipauth_ipconfiguration.php
@@ -1,84 +1,84 @@
 <?php
 $ll = 'LLL:EXT:sfpipauth/Resources/Private/Language/locallang_db.xlf:';
 
-return array (
+return array(
 
-	'ctrl' => array (
-		'title' => $ll . 'tx_sfpipauth_ipconfiguration',
-		'label' => 'name',
-		'tstamp' => 'tstamp',
-		'crdate' => 'crdate',
-		'cruser_id' => 'cruser_id',
-		'default_sortby' => 'ORDER BY crdate',
-		'delete' => 'deleted',
-		'enablecolumns' => array (
-			'disabled' => 'hidden',
-		),
-		'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath('sfpipauth') . 'Resources/Public/Icons/tx_sfpipauth_ipconfiguration.gif',
-		'hideTable' => false,
-		'dividers2tabs' => 1,
-		'searchFields' => 'name, ip'
-	),
-	'interface' => array (
-		'showRecordFieldList' => 'hidden, name, ip,feusers, loginmode'
-	),
-	'types' => array (
-		'0' => array ('showitem' => 'name, ip, feusers, loginmode, hidden')
-	),
-	'palettes' => array(
-		'canNotCollapse' => '1'
-	),
-	'columns' => array (
-		'hidden' => array(
-			'l10n_mode' => 'exclude',
-			'exclude' => 1,
-			'label' => 'LLL:EXT:lang/locallang_general.xlf:LGL.hidden',
-			'config' => array(
-				'type' => 'check',
-			),
-		),
-		'name' => array (
-			'exclude' => 0,
-			'label' => $ll . 'tx_sfpipauth_ipconfiguration.name',
-			'config' => array (
-				'type' => 'input',
-				'size' => '30',
-				'eval' => 'required',
-			)
-		),
-		'ip' => array (
-			'exclude' => 0,
-			'label' => $ll . 'tx_sfpipauth_ipconfiguration.ip',
-			'config' => array (
-				'type' => 'input',
-				'size' => '30',
-				'eval' => 'required',
-			)
-		),
-		'feusers' => array (
-			'exclude' => 0,
-			'label' => $ll . 'tx_sfpipauth_ipconfiguration.feusers',
-			'config' => array (
-				'type' => 'group',
-				'internal_type' => 'db',
-				'allowed' => 'fe_users',
-				'size' => 1,
-				'minitems' => 0,
-				'maxitems' => 1,
-			)
-		),
-		'loginmode' => array (
-			'exclude' => 0,
-			'label' => $ll . 'tx_sfpipauth_ipconfiguration.loginmode',
-			'config' => array (
-				'type' => 'select',
-				'items' => array (
-					array ($ll . 'tx_sfpipauth_ipconfiguration.loginmode.I.1', 1),
-					array ($ll . 'tx_sfpipauth_ipconfiguration.loginmode.I.2', 2),
-					array ($ll . 'tx_sfpipauth_ipconfiguration.loginmode.I.3', 3),
-				),
-			)
-		),
-	)
+    'ctrl' => array(
+        'title' => $ll . 'tx_sfpipauth_ipconfiguration',
+        'label' => 'name',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'default_sortby' => 'ORDER BY crdate',
+        'delete' => 'deleted',
+        'enablecolumns' => array(
+            'disabled' => 'hidden',
+        ),
+        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath('sfpipauth') . 'Resources/Public/Icons/tx_sfpipauth_ipconfiguration.gif',
+        'hideTable' => false,
+        'dividers2tabs' => 1,
+        'searchFields' => 'name, ip'
+    ),
+    'interface' => array(
+        'showRecordFieldList' => 'hidden, name, ip,feusers, loginmode'
+    ),
+    'types' => array(
+        '0' => array('showitem' => 'name, ip, feusers, loginmode, hidden')
+    ),
+    'palettes' => array(
+        'canNotCollapse' => '1'
+    ),
+    'columns' => array(
+        'hidden' => array(
+            'l10n_mode' => 'exclude',
+            'exclude' => 1,
+            'label' => 'LLL:EXT:lang/locallang_general.xlf:LGL.hidden',
+            'config' => array(
+                'type' => 'check',
+            ),
+        ),
+        'name' => array(
+            'exclude' => 0,
+            'label' => $ll . 'tx_sfpipauth_ipconfiguration.name',
+            'config' => array(
+                'type' => 'input',
+                'size' => '30',
+                'eval' => 'required',
+            )
+        ),
+        'ip' => array(
+            'exclude' => 0,
+            'label' => $ll . 'tx_sfpipauth_ipconfiguration.ip',
+            'config' => array(
+                'type' => 'input',
+                'size' => '30',
+                'eval' => 'required',
+            )
+        ),
+        'feusers' => array(
+            'exclude' => 0,
+            'label' => $ll . 'tx_sfpipauth_ipconfiguration.feusers',
+            'config' => array(
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'fe_users',
+                'size' => 1,
+                'minitems' => 0,
+                'maxitems' => 1,
+            )
+        ),
+        'loginmode' => array(
+            'exclude' => 0,
+            'label' => $ll . 'tx_sfpipauth_ipconfiguration.loginmode',
+            'config' => array(
+                'type' => 'select',
+                'items' => array(
+                    array($ll . 'tx_sfpipauth_ipconfiguration.loginmode.I.1', 1),
+                    array($ll . 'tx_sfpipauth_ipconfiguration.loginmode.I.2', 2),
+                    array($ll . 'tx_sfpipauth_ipconfiguration.loginmode.I.3', 3),
+                ),
+            )
+        ),
+    )
 
 );

--- a/Configuration/TCA/tx_sfpipauth_ipconfiguration.php
+++ b/Configuration/TCA/tx_sfpipauth_ipconfiguration.php
@@ -14,7 +14,9 @@ return array(
         'enablecolumns' => array(
             'disabled' => 'hidden',
         ),
-        'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath('sfpipauth') . 'Resources/Public/Icons/tx_sfpipauth_ipconfiguration.gif',
+        'iconfile' => \TYPO3\CMS\Core\Utility\PathUtility::stripPathSitePrefix(
+                \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('sfpipauth'))
+            . 'Resources/Public/Icons/tx_sfpipauth_ipconfiguration.gif',
         'hideTable' => false,
         'dividers2tabs' => 1,
         'searchFields' => 'name, ip'

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         }
     ],
     "require": {
-        "typo3/cms-backend": ">=7.6 <8.8",
-        "typo3/cms-core": ">=7.6 <8.8"
+        "typo3/cms-backend": ">=9.5.5 <10",
+        "typo3/cms-core": ">=9.5.5 <10"
     },
     "autoload": {
         "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -31,7 +31,7 @@ $EM_CONF[$_EXTKEY] = array(
             'depends' =>
                 array(
                     'php' => '5.4-0.0.0',
-                    'typo3' => '6.2.0-8.7.99'
+                    'typo3' => '9.5.5-9.5.99'
                 ),
             'conflicts' =>
                 array(),

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -4,38 +4,38 @@
  * Extension Manager/Repository config file.
  ***************************************************************/
 
-$EM_CONF[$_EXTKEY] = array (
-	'title' => 'snowflake: IP Authentication Service',
-	'description' => 'This is a very fast service to log in and/or block Users by their IP.',
-	'category' => 'services',
-	'shy' => 0,
-	'version' => '2.1.1',
-	'dependencies' => '',
-	'conflicts' => '',
-	'priority' => '',
-	'loadOrder' => '',
-	'module' => '',
-	'state' => 'stable',
-	'uploadfolder' => 0,
-	'createDirs' => '',
-	'modify_tables' => '',
-	'clearcacheonload' => 0,
-	'lockType' => '',
-	'author' => 'Christoph Buchli',
-	'author_email' => 'support@snowflake.ch',
-	'author_company' => 'snowflake productions gmbh',
-	'CGLcompliance' => NULL,
-	'CGLcompliance_note' => NULL,
-	'constraints' =>
-		array (
-			'depends' =>
-				array (
-					'php' => '5.4-0.0.0',
-					'typo3' => '6.2.0-8.7.99'
-				),
-			'conflicts' =>
-				array (),
-			'suggests' =>
-				array (),
-		),
+$EM_CONF[$_EXTKEY] = array(
+    'title' => 'snowflake: IP Authentication Service',
+    'description' => 'This is a very fast service to log in and/or block Users by their IP.',
+    'category' => 'services',
+    'shy' => 0,
+    'version' => '2.1.1',
+    'dependencies' => '',
+    'conflicts' => '',
+    'priority' => '',
+    'loadOrder' => '',
+    'module' => '',
+    'state' => 'stable',
+    'uploadfolder' => 0,
+    'createDirs' => '',
+    'modify_tables' => '',
+    'clearcacheonload' => 0,
+    'lockType' => '',
+    'author' => 'Christoph Buchli',
+    'author_email' => 'support@snowflake.ch',
+    'author_company' => 'snowflake productions gmbh',
+    'CGLcompliance' => null,
+    'CGLcompliance_note' => null,
+    'constraints' =>
+        array(
+            'depends' =>
+                array(
+                    'php' => '5.4-0.0.0',
+                    'typo3' => '6.2.0-8.7.99'
+                ),
+            'conflicts' =>
+                array(),
+            'suggests' =>
+                array(),
+        ),
 );


### PR DESCRIPTION
This change no longer supports older TYPO3 versions. It is possibly advisable to branch current master to support versions 8 and below separately or merge this into another branch. 

I made changes based on what the core Extension Scanner showed. Basic tests work (extension installation), setting up an "IP-Authentication configuration", assigning an FE User and testing if a page displayed for IP address range. 

What did not work was selecting an FE group in the configuration record, only FE user. I don't know if that is related to my changes, I might test on TYPO3 8 with current master. 

Only did basic tests so far. 